### PR TITLE
Add VACUUM to non transactional keywords

### DIFF
--- a/django_north/management/runner.py
+++ b/django_north/management/runner.py
@@ -125,7 +125,7 @@ class Script(object):
     def contains_non_transactional_keyword(self, file_handler):
         keywords = getattr(
             settings, 'NORTH_NON_TRANSACTIONAL_KEYWORDS',
-            ['CONCURRENTLY', 'ALTER TYPE'])
+            ['CONCURRENTLY', 'ALTER TYPE', 'VACUUM'])
         for line in file_handler:
             for kw in keywords:
                 if kw.lower() in line.lower():


### PR DESCRIPTION
VACUUM cannot be run inside a transaction, so it should be added to the list. Apparently there is no such issue with ANALYZE though.